### PR TITLE
商品サンプルデータ用 ProductSeeder を追加

### DIFF
--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Product;
+use Faker\Factory as Faker;
+
+class ProductSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $faker = Faker::create('ja_JP');
+
+        $products = [];
+        $now = now();
+
+        $recordCount = 30;
+
+        for ($i = 0; $i < $recordCount; $i++) {
+            $products[] = [
+                'name' => mb_substr($faker->unique()->realText(20), 0, 20),
+                'description' => $faker->optional(0.7)->realText(120),
+                'rating' => $faker->randomFloat(1, 0, 5),
+                'download_count' => $faker->numberBetween(0, 10000),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        Product::insert($products);
+    }
+}


### PR DESCRIPTION
## 概要
このPRでは、database/seeders/ProductSeeder.php を追加し、日本語Fakerで30件のサンプルプロダクトを生成・挿入できるようにしました。

## 変更点
- 新規: database/seeders/ProductSeeder.php
- 削除: database/seeders/.gitkeep