### PR TITLE
fix(api): normalize ranking/product responses

### DIFF
--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -134,7 +134,7 @@ class ProductController extends Controller
         $productArray = $product->toArray();
         $productArray['image_url'] = json_decode($product->image_url, true);
     
-        return response()->json($product);
+        return response()->json($productArray);
     }
 
     // PUT /products/{productId}
@@ -183,7 +183,7 @@ class ProductController extends Controller
         $productArray = $product->toArray();
         $productArray['image_url'] = json_decode($product->image_url, true);
 
-        return response()->json($product);
+        return response()->json($productArray);
     }
 
     // DELETE /products/{productId}

--- a/app/Http/Controllers/Api/RankingController.php
+++ b/app/Http/Controllers/Api/RankingController.php
@@ -6,24 +6,74 @@ use App\Http\Controllers\Controller;
 use App\Models\Product;
 use Illuminate\Http\Request;
 
+use function array_filter;
+use function array_values;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_last_error;
+
+
 class RankingController extends Controller
 {
     // GET /rankings
     public function index(Request $request)
     {
-        $rankings = Product::orderBy('rating', 'desc')
-                        ->take(5)
-                        ->get();
-        // ランキングが見つからなかった場合の処理
-        if ($rankings->isEmpty()) {
-            return response()->json([
-                'message' => 'No rankings found',
-                'data' => null
-            ], 404);
-        }
+        $limit = (int) $request->input('limit', 10);
+        $limit = max(1, min(20, $limit));
+
+        $rankings = Product::with('categories:id,name')
+            ->orderByDesc('rating')
+            ->orderByDesc('download_count')
+            ->take($limit)
+            ->get()
+            ->map(function (Product $product) {
+                $categories = $product->categories->map(static function ($category) {
+                    return [
+                        'id' => $category->id,
+                        'name' => $category->name,
+                    ];
+                })->values();
+
+                return [
+                    'id' => $product->id,
+                    'name' => $product->name,
+                    'description' => $product->description,
+                    'rating' => (float) $product->rating,
+                    'download_count' => (int) $product->download_count,
+                    'image_urls' => $this->normalizeImageUrls($product->getRawOriginal('image_url')),
+                    'category_ids' => $product->categoryIds,
+                    'categories' => $categories,
+                ];
+            })->values();
+
         return response()->json([
-            'message' => 'Ranking result',
-            'data' => $rankings // ランキング結果データ
-        ]);
+            'message' => $rankings->isEmpty() ? 'No rankings found' : 'Ranking result',
+            'items' => $rankings,
+            'count' => $rankings->count(),
+        ], 200);
+    }
+
+    private function normalizeImageUrls(?string $raw): array
+    {
+        if ($raw === null || $raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            if (is_array($decoded)) {
+                return array_values(array_filter($decoded, static function ($url) {
+                    return is_string($url) && $url !== '';
+                }));
+            }
+
+            if (is_string($decoded) && $decoded !== '') {
+                return [$decoded];
+            }
+        }
+
+        return is_string($raw) ? [$raw] : [];
     }
 }


### PR DESCRIPTION
- ProductController.php: `show` と `update` が常に `image_url` を配列へ復元した `productArray` を返すように整理し、フロントが追加パース無しで扱える形に統一。  
- RankingController.php: ランキング取得を再実装し、クエリで件数を制御、カテゴリ情報や `image_urls: string[]` を正規化した上で `items` と `count` を 200 レスポンスとして返却する処理を追加。  
。